### PR TITLE
Update to 0.12.0-alpha

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM lightninglabs/lightning-terminal:v0.11.0-alpha
+FROM lightninglabs/lightning-terminal:v0.12.0-alpha
 # arm64 or amd64
 ARG PLATFORM
 ARG ARCH

--- a/manifest.yaml
+++ b/manifest.yaml
@@ -1,8 +1,8 @@
 id: lightning-terminal
 title: Lightning Terminal
-version: 0.11.0.1
+version: 0.12.0
 release-notes: |
-  * Fix bug where password was not saved on fresh install
+  * Update upstream to v0.12.0 [Release Notes](https://github.com/lightninglabs/lightning-terminal/releases/tag/v0.12.0-alpha)
 license: mit
 wrapper-repo: https://github.com/Start9Labs/lightning-terminal-wrapper
 upstream-repo: https://github.com/lightninglabs/lightning-terminal

--- a/scripts/procedures/migrations.ts
+++ b/scripts/procedures/migrations.ts
@@ -1,4 +1,4 @@
 import { compat, types as T } from "../deps.ts";
 
 export const migration: T.ExpectedExports.migration =
-  compat.migrations.fromMapping({}, "0.11.0.1");
+  compat.migrations.fromMapping({}, "0.12.0");


### PR DESCRIPTION
Update upstream to [0.12.0-alpha](https://github.com/lightninglabs/lightning-terminal/releases/tag/v0.12.0-alpha) 