### PR TITLE
Fix for error on backup of dirs to rsync with sticky bits set

### DIFF
--- a/scripts/procedures/backups.ts
+++ b/scripts/procedures/backups.ts
@@ -1,3 +1,7 @@
 import { Backups } from "../deps.ts";
 
-export const { createBackup, restoreBackup } = Backups.volumes("main").build();
+export const { createBackup, restoreBackup } = Backups.with_options({
+  exclude: [".lnd"],
+})
+  .volumes("main")
+  .build();


### PR DESCRIPTION
I have confirmed that this PR fixes this issue with Lit:

https://github.com/Start9Labs/start-os/issues/2564