### PR TITLE
chore: bump start-sdk to 1.5.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,11 +1,11 @@
 {
-  "name": "lightning-terminal-startos",
+  "name": "slot-1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "dependencies": {
-        "@start9labs/start-sdk": "1.3.3",
+        "@start9labs/start-sdk": "1.5.0",
         "lnd-startos": "github:Start9Labs/lnd-startos#master"
       },
       "devDependencies": {
@@ -49,6 +49,72 @@
       }
     },
     "node_modules/@nodable/entities": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@nodable/entities/-/entities-2.1.0.tgz",
+      "integrity": "sha512-nyT7T3nbMyBI/lvr6L5TyWbFJAI9FTgVRakNoBqCD+PmID8DzFrrNdLLtHMwMszOtqZa8PAOV24ZqDnQrhQINA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/nodable"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/@start9labs/start-sdk": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/@start9labs/start-sdk/-/start-sdk-1.5.0.tgz",
+      "integrity": "sha512-nsbJdXU2eZS8EFOVH68nOgQvDi/dAN0Swd37od4Luyu+ajKEKTdyt30fze/CbdaXF8gwV54D8A2k3uni1KnLBQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@iarna/toml": "^3.0.0",
+        "@noble/curves": "^1.9.7",
+        "@noble/hashes": "^1.8.0",
+        "@types/ini": "^4.1.1",
+        "deep-equality-data-structures": "^2.0.0",
+        "fast-xml-parser": "~5.7.0",
+        "ini": "^5.0.0",
+        "isomorphic-fetch": "^3.0.0",
+        "mime": "^4.1.0",
+        "yaml": "^2.8.3",
+        "zod": "4.3.6",
+        "zod-deep-partial": "^1.2.0"
+      }
+    },
+    "node_modules/@types/ini": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/@types/ini/-/ini-4.1.1.tgz",
+      "integrity": "sha512-MIyNUZipBTbyUNnhvuXJTY7B6qNI78meck9Jbv3wk0OgNwRyOOVEKDutAkOs1snB/tx0FafyR6/SN4Ps0hZPeg==",
+      "license": "MIT"
+    },
+    "node_modules/@types/node": {
+      "version": "22.19.19",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.19.19.tgz",
+      "integrity": "sha512-dyh/xO2Fh5bYrfWaaqGrRQQGkNdmYw6AmaAUvYeUMNTWQtvb796ikLdmTchRmOlOiIJ1TDXfWgVx1QkUlQ6Hew==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~6.21.0"
+      }
+    },
+    "node_modules/@vercel/ncc": {
+      "version": "0.38.4",
+      "resolved": "https://registry.npmjs.org/@vercel/ncc/-/ncc-0.38.4.tgz",
+      "integrity": "sha512-8LwjnlP39s08C08J5NstzriPvW1SP8Zfpp1BvC2sI35kPeZnHfxVkCwu4/+Wodgnd60UtT1n8K8zw+Mp7J9JmQ==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "ncc": "dist/ncc/cli.js"
+      }
+    },
+    "node_modules/bitcoin-core-startos": {
+      "name": "bitcoin-core",
+      "resolved": "git+ssh://git@github.com/Start9Labs/bitcoin-core-startos.git#b3bc91c970db6822b38228b07b646ec7ad3138fa",
+      "dependencies": {
+        "@start9labs/start-sdk": "1.3.3",
+        "diskusage": "^1.2.0"
+      }
+    },
+    "node_modules/bitcoin-core-startos/node_modules/@nodable/entities": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/@nodable/entities/-/entities-1.1.0.tgz",
       "integrity": "sha512-bidpxmTBP0pOsxULw6XlxzQpTgrAGLDHGBK/JuWhPDL6ZV0GZ/PmN9CA9do6e+A9lYI6qx6ikJUtJYRxup141g==",
@@ -60,7 +126,7 @@
       ],
       "license": "MIT"
     },
-    "node_modules/@start9labs/start-sdk": {
+    "node_modules/bitcoin-core-startos/node_modules/@start9labs/start-sdk": {
       "version": "1.3.3",
       "resolved": "https://registry.npmjs.org/@start9labs/start-sdk/-/start-sdk-1.3.3.tgz",
       "integrity": "sha512-aL9ilSj6CyP2+tSooxPZFqWXP1/1dMgYljcu1s2ECoPv6CTmSBqwrBw9SdsQp7PYmnU4rsSZQteWogkDOf93YQ==",
@@ -80,58 +146,25 @@
         "zod-deep-partial": "^1.2.0"
       }
     },
-    "node_modules/@types/ini": {
-      "version": "4.1.1",
-      "resolved": "https://registry.npmjs.org/@types/ini/-/ini-4.1.1.tgz",
-      "integrity": "sha512-MIyNUZipBTbyUNnhvuXJTY7B6qNI78meck9Jbv3wk0OgNwRyOOVEKDutAkOs1snB/tx0FafyR6/SN4Ps0hZPeg==",
-      "license": "MIT"
-    },
-    "node_modules/@types/node": {
-      "version": "22.19.15",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.19.15.tgz",
-      "integrity": "sha512-F0R/h2+dsy5wJAUe3tAU6oqa2qbWY5TpNfL/RGmo1y38hiyO1w3x2jPtt76wmuaJI4DQnOBu21cNXQ2STIUUWg==",
-      "dev": true,
+    "node_modules/bitcoin-core-startos/node_modules/fast-xml-parser": {
+      "version": "5.6.0",
+      "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-5.6.0.tgz",
+      "integrity": "sha512-5G+uaEBbOm9M4dgMOV3K/rBzfUNGqGqoUTaYJM3hBwM8t71w07gxLQZoTsjkY8FtfjabqgQHEkeIySBDYeBmJw==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/NaturalIntelligence"
+        }
+      ],
       "license": "MIT",
       "dependencies": {
-        "undici-types": "~6.21.0"
-      }
-    },
-    "node_modules/@vercel/ncc": {
-      "version": "0.38.4",
-      "resolved": "https://registry.npmjs.org/@vercel/ncc/-/ncc-0.38.4.tgz",
-      "integrity": "sha512-8LwjnlP39s08C08J5NstzriPvW1SP8Zfpp1BvC2sI35kPeZnHfxVkCwu4/+Wodgnd60UtT1n8K8zw+Mp7J9JmQ==",
-      "dev": true,
-      "license": "MIT",
+        "@nodable/entities": "^1.1.0",
+        "fast-xml-builder": "^1.1.4",
+        "path-expression-matcher": "^1.5.0",
+        "strnum": "^2.2.3"
+      },
       "bin": {
-        "ncc": "dist/ncc/cli.js"
-      }
-    },
-    "node_modules/bitcoin-core-startos": {
-      "name": "bitcoin-core",
-      "resolved": "git+ssh://git@github.com/Start9Labs/bitcoin-core-startos.git#e873695fc4e9fa5a21d13db9b56edbb1dab48d08",
-      "dependencies": {
-        "@start9labs/start-sdk": "1.3.2",
-        "diskusage": "^1.2.0"
-      }
-    },
-    "node_modules/bitcoin-core-startos/node_modules/@start9labs/start-sdk": {
-      "version": "1.3.2",
-      "resolved": "https://registry.npmjs.org/@start9labs/start-sdk/-/start-sdk-1.3.2.tgz",
-      "integrity": "sha512-Iw26tSjN+2yKYul8VabrV9VtpbHnEes4FCCxhGrmdFzjP/wc+K4DLqN+cLgqwtVebVB0mJVhhh63nbRil1pqWg==",
-      "license": "MIT",
-      "dependencies": {
-        "@iarna/toml": "^3.0.0",
-        "@noble/curves": "^1.9.7",
-        "@noble/hashes": "^1.8.0",
-        "@types/ini": "^4.1.1",
-        "deep-equality-data-structures": "^2.0.0",
-        "fast-xml-parser": "~5.6.0",
-        "ini": "^5.0.0",
-        "isomorphic-fetch": "^3.0.0",
-        "mime": "^4.1.0",
-        "yaml": "^2.8.3",
-        "zod": "^4.3.6",
-        "zod-deep-partial": "^1.2.0"
+        "fxparser": "src/cli/cli.js"
       }
     },
     "node_modules/deep-equality-data-structures": {
@@ -161,9 +194,9 @@
       "license": "MIT"
     },
     "node_modules/fast-xml-builder": {
-      "version": "1.1.5",
-      "resolved": "https://registry.npmjs.org/fast-xml-builder/-/fast-xml-builder-1.1.5.tgz",
-      "integrity": "sha512-4TJn/8FKLeslLAH3dnohXqE3QSoxkhvaMzepOIZytwJXZO69Bfz0HBdDHzOTOon6G59Zrk6VQ2bEiv1t61rfkA==",
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/fast-xml-builder/-/fast-xml-builder-1.2.0.tgz",
+      "integrity": "sha512-00aAWieqff+ZJhsXA4g1g7M8k+7AYoMUUHF+/zFb5U6Uv/P0Vl4QZo84/IcufzYalLuEj9928bXN9PbbFzMF0Q==",
       "funding": [
         {
           "type": "github",
@@ -172,13 +205,14 @@
       ],
       "license": "MIT",
       "dependencies": {
-        "path-expression-matcher": "^1.1.3"
+        "path-expression-matcher": "^1.5.0",
+        "xml-naming": "^0.1.0"
       }
     },
     "node_modules/fast-xml-parser": {
-      "version": "5.6.0",
-      "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-5.6.0.tgz",
-      "integrity": "sha512-5G+uaEBbOm9M4dgMOV3K/rBzfUNGqGqoUTaYJM3hBwM8t71w07gxLQZoTsjkY8FtfjabqgQHEkeIySBDYeBmJw==",
+      "version": "5.7.3",
+      "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-5.7.3.tgz",
+      "integrity": "sha512-C0AaNuC+mscy6vrAQKAc/rMq+zAPHodfHGZu4sGVehvAQt/JLG1O5zEcYcXSY5zSqr4YVgxsB+pHXTq0i7eDlg==",
       "funding": [
         {
           "type": "github",
@@ -187,8 +221,8 @@
       ],
       "license": "MIT",
       "dependencies": {
-        "@nodable/entities": "^1.1.0",
-        "fast-xml-builder": "^1.1.4",
+        "@nodable/entities": "^2.1.0",
+        "fast-xml-builder": "^1.1.7",
         "path-expression-matcher": "^1.5.0",
         "strnum": "^2.2.3"
       },
@@ -216,18 +250,30 @@
       }
     },
     "node_modules/lnd-startos": {
-      "resolved": "git+ssh://git@github.com/Start9Labs/lnd-startos.git#0a3ab8f4783b04f70bd6f2b735890f5fc850674c",
+      "resolved": "git+ssh://git@github.com/Start9Labs/lnd-startos.git#7e9e273ebe9a9e5c9854426c5c93ea0a1bfbd68b",
       "dependencies": {
-        "@start9labs/start-sdk": "1.3.2",
+        "@start9labs/start-sdk": "1.3.3",
         "bitcoin-core-startos": "github:Start9Labs/bitcoin-core-startos#28.x",
         "mime": "^4.0.7",
         "rfc4648": "1.5.4"
       }
     },
+    "node_modules/lnd-startos/node_modules/@nodable/entities": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@nodable/entities/-/entities-1.1.0.tgz",
+      "integrity": "sha512-bidpxmTBP0pOsxULw6XlxzQpTgrAGLDHGBK/JuWhPDL6ZV0GZ/PmN9CA9do6e+A9lYI6qx6ikJUtJYRxup141g==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/nodable"
+        }
+      ],
+      "license": "MIT"
+    },
     "node_modules/lnd-startos/node_modules/@start9labs/start-sdk": {
-      "version": "1.3.2",
-      "resolved": "https://registry.npmjs.org/@start9labs/start-sdk/-/start-sdk-1.3.2.tgz",
-      "integrity": "sha512-Iw26tSjN+2yKYul8VabrV9VtpbHnEes4FCCxhGrmdFzjP/wc+K4DLqN+cLgqwtVebVB0mJVhhh63nbRil1pqWg==",
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/@start9labs/start-sdk/-/start-sdk-1.3.3.tgz",
+      "integrity": "sha512-aL9ilSj6CyP2+tSooxPZFqWXP1/1dMgYljcu1s2ECoPv6CTmSBqwrBw9SdsQp7PYmnU4rsSZQteWogkDOf93YQ==",
       "license": "MIT",
       "dependencies": {
         "@iarna/toml": "^3.0.0",
@@ -242,6 +288,27 @@
         "yaml": "^2.8.3",
         "zod": "^4.3.6",
         "zod-deep-partial": "^1.2.0"
+      }
+    },
+    "node_modules/lnd-startos/node_modules/fast-xml-parser": {
+      "version": "5.6.0",
+      "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-5.6.0.tgz",
+      "integrity": "sha512-5G+uaEBbOm9M4dgMOV3K/rBzfUNGqGqoUTaYJM3hBwM8t71w07gxLQZoTsjkY8FtfjabqgQHEkeIySBDYeBmJw==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/NaturalIntelligence"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "@nodable/entities": "^1.1.0",
+        "fast-xml-builder": "^1.1.4",
+        "path-expression-matcher": "^1.5.0",
+        "strnum": "^2.2.3"
+      },
+      "bin": {
+        "fxparser": "src/cli/cli.js"
       }
     },
     "node_modules/mime": {
@@ -260,9 +327,9 @@
       }
     },
     "node_modules/nan": {
-      "version": "2.26.2",
-      "resolved": "https://registry.npmjs.org/nan/-/nan-2.26.2.tgz",
-      "integrity": "sha512-0tTvBTYkt3tdGw22nrAy50x7gpbGCCFH3AFcyS5WiUu7Eu4vWlri1woE6qHBSfy11vksDqkiwjOnlR7WV8G1Hw==",
+      "version": "2.27.0",
+      "resolved": "https://registry.npmjs.org/nan/-/nan-2.27.0.tgz",
+      "integrity": "sha512-hC+0LidcL3XE4rp1C4H54KujgXKzbfyTngZTwBByQxsOxCEKZT0MPQ4hOKUH2jU1OYstqdDH4onyHPDzcV0XdQ==",
       "license": "MIT"
     },
     "node_modules/node-fetch": {
@@ -310,9 +377,9 @@
       }
     },
     "node_modules/prettier": {
-      "version": "3.8.1",
-      "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.8.1.tgz",
-      "integrity": "sha512-UOnG6LftzbdaHZcKoPFtOcCKztrQ57WkHDeRD9t/PTQtmT0NHSeWWepj6pS0z/N7+08BHFDQVUrfmfMRcZwbMg==",
+      "version": "3.8.3",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.8.3.tgz",
+      "integrity": "sha512-7igPTM53cGHMW8xWuVTydi2KO233VFiTNyF5hLJqpilHfmn8C8gPf+PS7dUT64YcXFbiMGZxS9pCSxL/Dxm/Jw==",
       "dev": true,
       "license": "MIT",
       "bin": {
@@ -332,9 +399,9 @@
       "license": "MIT"
     },
     "node_modules/strnum": {
-      "version": "2.2.3",
-      "resolved": "https://registry.npmjs.org/strnum/-/strnum-2.2.3.tgz",
-      "integrity": "sha512-oKx6RUCuHfT3oyVjtnrmn19H1SiCqgJSg+54XqURKp5aCMbrXrhLjRN9TjuwMjiYstZ0MzDrHqkGZ5dFTKd+zg==",
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/strnum/-/strnum-2.3.0.tgz",
+      "integrity": "sha512-ums3KNd42PGyx5xaoVTO1mjU1bH3NpY4vsrVlnv9PNGqQj8wd7rJ6nEypLrJ7z5vxK5RP0yMLo6J/Gsm62DI5Q==",
       "funding": [
         {
           "type": "github",
@@ -392,10 +459,25 @@
         "webidl-conversions": "^3.0.0"
       }
     },
+    "node_modules/xml-naming": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/xml-naming/-/xml-naming-0.1.0.tgz",
+      "integrity": "sha512-k8KO9hrMyNk6tUWqUfkTEZbezRRpONVOzUTnc97VnCvyj6Tf9lyUR9EDAIeiVLv56jsMcoXEwjW8Kv5yPY52lw==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/NaturalIntelligence"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
     "node_modules/yaml": {
-      "version": "2.8.3",
-      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.8.3.tgz",
-      "integrity": "sha512-AvbaCLOO2Otw/lW5bmh9d/WEdcDFdQp2Z2ZUH3pX9U2ihyUY0nvLv7J6TrWowklRGPYbB/IuIMfYgxaCPg5Bpg==",
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.9.0.tgz",
+      "integrity": "sha512-2AvhNX3mb8zd6Zy7INTtSpl1F15HW6Wnqj0srWlkKLcpYl/gMIMJiyuGq2KeI2YFxUPjdlB+3Lc10seMLtL4cA==",
       "license": "ISC",
       "bin": {
         "yaml": "bin.mjs"
@@ -412,7 +494,6 @@
       "resolved": "https://registry.npmjs.org/zod/-/zod-4.3.6.tgz",
       "integrity": "sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg==",
       "license": "MIT",
-      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
     "check": "tsc --noEmit"
   },
   "dependencies": {
-    "@start9labs/start-sdk": "1.3.3",
+    "@start9labs/start-sdk": "1.5.0",
     "lnd-startos": "github:Start9Labs/lnd-startos#master"
   },
   "devDependencies": {

--- a/startos/versions/index.ts
+++ b/startos/versions/index.ts
@@ -1,7 +1,7 @@
 import { VersionGraph } from '@start9labs/start-sdk'
-import { v_0_16_1_alpha_3 } from './v0.16.1.alpha.3'
+import { v_0_16_1_alpha_4 } from './v0.16.1.alpha.4'
 
 export const versionGraph = VersionGraph.of({
-  current: v_0_16_1_alpha_3,
+  current: v_0_16_1_alpha_4,
   other: [],
 })

--- a/startos/versions/v0.16.1.alpha.4.ts
+++ b/startos/versions/v0.16.1.alpha.4.ts
@@ -2,14 +2,14 @@ import { VersionInfo, IMPOSSIBLE, YAML } from '@start9labs/start-sdk'
 import { readFile, rm } from 'fs/promises'
 import { litConfig } from '../fileModels/lit.conf'
 
-export const v_0_16_1_alpha_3 = VersionInfo.of({
-  version: '0.16.1-alpha:3',
+export const v_0_16_1_alpha_4 = VersionInfo.of({
+  version: '0.16.1-alpha:4',
   releaseNotes: {
-    en_US: 'Internal updates (start-sdk 1.3.3)',
-    es_ES: 'Actualizaciones internas (start-sdk 1.3.3)',
-    de_DE: 'Interne Aktualisierungen (start-sdk 1.3.3)',
-    pl_PL: 'Aktualizacje wewnętrzne (start-sdk 1.3.3)',
-    fr_FR: 'Mises à jour internes (start-sdk 1.3.3)',
+    en_US: 'Internal updates (start-sdk 1.5.0)',
+    es_ES: 'Actualizaciones internas (start-sdk 1.5.0)',
+    de_DE: 'Interne Aktualisierungen (start-sdk 1.5.0)',
+    pl_PL: 'Aktualizacje wewnętrzne (start-sdk 1.5.0)',
+    fr_FR: 'Mises à jour internes (start-sdk 1.5.0)',
   },
   migrations: {
     up: async ({ effects }) => {


### PR DESCRIPTION
## Summary

- Bumps `@start9labs/start-sdk` from 1.3.3 → 1.5.0
- Refreshes transitive deps via `npm update`
- Releases as `0.16.1-alpha:4`

No upstream Lightning Terminal bump — `v0.16.1-alpha` (Feb 2026) is still the latest upstream release. No breaking changes from the SDK bump; typecheck and `make` build are green for both `x86_64` and `aarch64`.

The prior version's pre-existing config-migration is preserved (renamed in place per the version-files convention).

## Test plan

- [x] `npm run check` passes
- [x] `make` builds `lightning-terminal_x86_64.s9pk` and `lightning-terminal_aarch64.s9pk`