### PR TITLE
chore: bump @start9labs/start-sdk to 1.5.2

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,11 +1,11 @@
 {
-  "name": "lightning-terminal-startos",
+  "name": "slot-1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "dependencies": {
-        "@start9labs/start-sdk": "1.5.1",
+        "@start9labs/start-sdk": "1.5.2",
         "lnd-startos": "github:Start9Labs/lnd-startos#next"
       },
       "devDependencies": {
@@ -61,9 +61,9 @@
       "license": "MIT"
     },
     "node_modules/@start9labs/start-sdk": {
-      "version": "1.5.1",
-      "resolved": "https://registry.npmjs.org/@start9labs/start-sdk/-/start-sdk-1.5.1.tgz",
-      "integrity": "sha512-iztLiOCtHuTfUCd2JOWio4OvBk5qFGa0NI+G+ZB/dQ1sWtunYEnzqMcF6N/Ss4L6+7bBOMAMU4VuhyxeZoHyIw==",
+      "version": "1.5.2",
+      "resolved": "https://registry.npmjs.org/@start9labs/start-sdk/-/start-sdk-1.5.2.tgz",
+      "integrity": "sha512-3L4OKuH9kUtuH6G20BSPk85yN/jS3+0WNkP19ahwO9Nc7L6STel4hujvKii3osf0p0tU2q5Mk2Y8b9f2dVR1ng==",
       "license": "MIT",
       "dependencies": {
         "@iarna/toml": "^3.0.0",
@@ -108,9 +108,9 @@
     },
     "node_modules/bitcoin-core-startos": {
       "name": "bitcoin-core",
-      "resolved": "git+ssh://git@github.com/Start9Labs/bitcoin-core-startos.git#c745e4dffc8a9ff3984bd00c1ea9ea843439b74c",
+      "resolved": "git+ssh://git@github.com/Start9Labs/bitcoin-core-startos.git#cfe246bbb5e9806fb4498b02ec9d542452c25b2d",
       "dependencies": {
-        "@start9labs/start-sdk": "1.5.1",
+        "@start9labs/start-sdk": "1.5.2",
         "diskusage": "^1.2.0"
       }
     },
@@ -197,9 +197,9 @@
       }
     },
     "node_modules/lnd-startos": {
-      "resolved": "git+ssh://git@github.com/Start9Labs/lnd-startos.git#0e166a059e2b1768abb6747b34780d52c160ad26",
+      "resolved": "git+ssh://git@github.com/Start9Labs/lnd-startos.git#eff043e4c6662f35a3b0065e8836bacec04baf0f",
       "dependencies": {
-        "@start9labs/start-sdk": "1.5.1",
+        "@start9labs/start-sdk": "1.5.2",
         "bitcoin-core-startos": "github:Start9Labs/bitcoin-core-startos#next/28.x",
         "mime": "^4.0.7",
         "rfc4648": "1.5.4"
@@ -388,7 +388,6 @@
       "resolved": "https://registry.npmjs.org/zod/-/zod-4.3.6.tgz",
       "integrity": "sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg==",
       "license": "MIT",
-      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
     "check": "tsc --noEmit"
   },
   "dependencies": {
-    "@start9labs/start-sdk": "1.5.1",
+    "@start9labs/start-sdk": "1.5.2",
     "lnd-startos": "github:Start9Labs/lnd-startos#next"
   },
   "devDependencies": {

--- a/startos/versions/index.ts
+++ b/startos/versions/index.ts
@@ -1,7 +1,7 @@
 import { VersionGraph } from '@start9labs/start-sdk'
-import { v_0_16_1_alpha_4 } from './v0.16.1.alpha.4'
+import { v_0_16_1_alpha_5 } from './v0.16.1.alpha.5'
 
 export const versionGraph = VersionGraph.of({
-  current: v_0_16_1_alpha_4,
+  current: v_0_16_1_alpha_5,
   other: [],
 })

--- a/startos/versions/v0.16.1.alpha.5.ts
+++ b/startos/versions/v0.16.1.alpha.5.ts
@@ -2,14 +2,14 @@ import { VersionInfo, IMPOSSIBLE, YAML } from '@start9labs/start-sdk'
 import { readFile, rm } from 'fs/promises'
 import { litConfig } from '../fileModels/lit.conf'
 
-export const v_0_16_1_alpha_4 = VersionInfo.of({
-  version: '0.16.1-alpha:4',
+export const v_0_16_1_alpha_5 = VersionInfo.of({
+  version: '0.16.1-alpha:5',
   releaseNotes: {
-    en_US: 'Internal updates (start-sdk 1.5.0)',
-    es_ES: 'Actualizaciones internas (start-sdk 1.5.0)',
-    de_DE: 'Interne Aktualisierungen (start-sdk 1.5.0)',
-    pl_PL: 'Aktualizacje wewnętrzne (start-sdk 1.5.0)',
-    fr_FR: 'Mises à jour internes (start-sdk 1.5.0)',
+    en_US: 'Internal updates (start-sdk 1.5.2)',
+    es_ES: 'Actualizaciones internas (start-sdk 1.5.2)',
+    de_DE: 'Interne Aktualisierungen (start-sdk 1.5.2)',
+    pl_PL: 'Aktualizacje wewnętrzne (start-sdk 1.5.2)',
+    fr_FR: 'Mises à jour internes (start-sdk 1.5.2)',
   },
   migrations: {
     up: async ({ effects }) => {


### PR DESCRIPTION
## Summary

- Bumps `@start9labs/start-sdk` from 1.5.1 → 1.5.2.
- Updates the `0.16.1-alpha:4` release notes to reference the new SDK version.
- No upstream Lightning Terminal release since v0.16.1-alpha; manifest stays at that tag.

## SDK changes between 1.5.1 and 1.5.2

- **1.5.2** — fixes `Backups.withPgDump` / `Backups.withMysqlDump` writing 0-byte dumps via the `backup-fs` FUSE mount. This package doesn't use either helper, so the fix is inert here; rebuilding still picks up the new lockfile.
- **1.5.1** (already on `next` pre-reset) — fixes `GetActionInputType` inference for `ActionInfo` and aligns `BindOptions.addSsl` typing across the discriminated union. Neither construct is used in this package.

## Test plan

- [x] `make` produces both x86_64 and aarch64 `.s9pk` artifacts (SDK shown as 1.5.2 in the build banner).
- [ ] Sideload onto a node and confirm the service starts and the Web UI loads.