### PR TITLE
chore: bump lightning-terminal to 0.17.0-alpha; 0.16.1-alpha:4 → 0.17.0-alpha:0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4,6 +4,7 @@
   "requires": true,
   "packages": {
     "": {
+      "name": "lightning-terminal-startos",
       "dependencies": {
         "@start9labs/start-sdk": "1.5.3",
         "lnd-startos": "github:Start9Labs/lnd-startos#next"
@@ -428,7 +429,6 @@
       "resolved": "https://registry.npmjs.org/zod/-/zod-4.3.6.tgz",
       "integrity": "sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg==",
       "license": "MIT",
-      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }

--- a/package.json
+++ b/package.json
@@ -1,4 +1,5 @@
 {
+  "name": "lightning-terminal-startos",
   "scripts": {
     "build": "rm -rf ./javascript && ncc build startos/index.ts -o ./javascript",
     "prettier": "prettier --write startos",

--- a/startos/actions/index.ts
+++ b/startos/actions/index.ts
@@ -1,5 +1,4 @@
 import { sdk } from '../sdk'
 import { resetPassword } from './resetPassword'
 
-export const actions = sdk.Actions.of()
-  .addAction(resetPassword)
+export const actions = sdk.Actions.of().addAction(resetPassword)

--- a/startos/fileModels/lit.conf.ts
+++ b/startos/fileModels/lit.conf.ts
@@ -15,6 +15,9 @@ const shape = z.object({
   'remote.lnd.rpcserver': z.literal(rpcServer).catch(rpcServer),
   'remote.lnd.macaroonpath': z.literal(macaroonPath).catch(macaroonPath),
   'remote.lnd.tlscertpath': z.literal(tlsCertPath).catch(tlsCertPath),
+  // v0.17 migrates bbolt→SQL by default, prompting on stdin; the daemon has no
+  // stdin, so pin bbolt to keep startup non-interactive and reversible.
+  databasebackend: z.literal('bbolt').catch('bbolt'),
 })
 
 export const litConfig = FileHelper.ini(

--- a/startos/manifest/index.ts
+++ b/startos/manifest/index.ts
@@ -5,8 +5,7 @@ export const manifest = setupManifest({
   id: 'lightning-terminal',
   title: 'Lightning Terminal',
   license: 'mit',
-  packageRepo:
-    'https://github.com/Start9Labs/lightning-terminal-startos',
+  packageRepo: 'https://github.com/Start9Labs/lightning-terminal-startos',
   upstreamRepo: 'https://github.com/lightninglabs/lightning-terminal',
   marketingUrl: 'https://lightning.engineering/',
   donationUrl: null,
@@ -15,7 +14,7 @@ export const manifest = setupManifest({
   images: {
     'lightning-terminal': {
       source: {
-        dockerTag: 'lightninglabs/lightning-terminal:v0.16.1-alpha',
+        dockerTag: 'lightninglabs/lightning-terminal:v0.17.0-alpha',
       },
       arch: ['aarch64', 'x86_64'],
     },

--- a/startos/versions/current.ts
+++ b/startos/versions/current.ts
@@ -3,13 +3,43 @@ import { readFile, rm } from 'fs/promises'
 import { litConfig } from '../fileModels/lit.conf'
 
 export const current = VersionInfo.of({
-  version: '0.16.1-alpha:4',
+  version: '0.17.0-alpha:0',
   releaseNotes: {
-    en_US: 'Internal updates (start-sdk 1.5.0)',
-    es_ES: 'Actualizaciones internas (start-sdk 1.5.0)',
-    de_DE: 'Interne Aktualisierungen (start-sdk 1.5.0)',
-    pl_PL: 'Aktualizacje wewnętrzne (start-sdk 1.5.0)',
-    fr_FR: 'Mises à jour internes (start-sdk 1.5.0)',
+    en_US: `Updated Lightning Terminal to 0.17.0-alpha.
+
+- Bundles lnd 0.21.1-beta, tapd 0.8.0, loop 0.33.3-beta, pool 0.7.1-beta, faraday 0.2.16-alpha.
+- Adds native SQL (SQLite/Postgres) database backends; the legacy bbolt backend is now deprecated. StartOS keeps bbolt for now to avoid the irreversible auto-migration; an opt-in migration will follow.
+- Restores LNC session setup for mailbox links and fixes account-update expiration handling.
+
+Full notes: https://github.com/lightninglabs/lightning-terminal/releases/tag/v0.17.0-alpha`,
+    es_ES: `Se actualizó Lightning Terminal a 0.17.0-alpha.
+
+- Incluye lnd 0.21.1-beta, tapd 0.8.0, loop 0.33.3-beta, pool 0.7.1-beta, faraday 0.2.16-alpha.
+- Añade backends de base de datos SQL nativos (SQLite/Postgres); el backend heredado bbolt queda obsoleto. StartOS mantiene bbolt por ahora para evitar la migración automática irreversible; se ofrecerá una migración opcional más adelante.
+- Restaura la configuración de sesión LNC para enlaces de buzón y corrige el manejo de la expiración al actualizar cuentas.
+
+Notas completas: https://github.com/lightninglabs/lightning-terminal/releases/tag/v0.17.0-alpha`,
+    de_DE: `Lightning Terminal auf 0.17.0-alpha aktualisiert.
+
+- Enthält lnd 0.21.1-beta, tapd 0.8.0, loop 0.33.3-beta, pool 0.7.1-beta, faraday 0.2.16-alpha.
+- Fügt native SQL-Datenbank-Backends (SQLite/Postgres) hinzu; das alte bbolt-Backend ist nun veraltet. StartOS behält vorerst bbolt, um die unumkehrbare automatische Migration zu vermeiden; eine optionale Migration folgt.
+- Stellt die LNC-Sitzungseinrichtung für Mailbox-Links wieder her und behebt die Behandlung des Kontoaktualisierungs-Ablaufs.
+
+Vollständige Hinweise: https://github.com/lightninglabs/lightning-terminal/releases/tag/v0.17.0-alpha`,
+    pl_PL: `Zaktualizowano Lightning Terminal do 0.17.0-alpha.
+
+- Zawiera lnd 0.21.1-beta, tapd 0.8.0, loop 0.33.3-beta, pool 0.7.1-beta, faraday 0.2.16-alpha.
+- Dodaje natywne backendy baz danych SQL (SQLite/Postgres); starszy backend bbolt jest teraz przestarzały. StartOS na razie pozostaje przy bbolt, aby uniknąć nieodwracalnej automatycznej migracji; opcjonalna migracja pojawi się później.
+- Przywraca konfigurację sesji LNC dla linków skrzynki pocztowej i naprawia obsługę wygasania przy aktualizacji kont.
+
+Pełne informacje: https://github.com/lightninglabs/lightning-terminal/releases/tag/v0.17.0-alpha`,
+    fr_FR: `Mise à jour de Lightning Terminal vers 0.17.0-alpha.
+
+- Intègre lnd 0.21.1-beta, tapd 0.8.0, loop 0.33.3-beta, pool 0.7.1-beta, faraday 0.2.16-alpha.
+- Ajoute des backends de base de données SQL natifs (SQLite/Postgres) ; l'ancien backend bbolt est désormais déprécié. StartOS conserve bbolt pour l'instant afin d'éviter la migration automatique irréversible ; une migration optionnelle suivra.
+- Restaure la configuration de session LNC pour les liens de boîte aux lettres et corrige la gestion de l'expiration lors de la mise à jour des comptes.
+
+Notes complètes : https://github.com/lightninglabs/lightning-terminal/releases/tag/v0.17.0-alpha`,
   },
   migrations: {
     up: async ({ effects }) => {


### PR DESCRIPTION
## Summary

Bumps the wrapped Lightning Terminal (`litd`) Docker image from **v0.16.1-alpha → v0.17.0-alpha** (StartOS `0.16.1-alpha:4 → 0.17.0-alpha:0`).

Upstream release: https://github.com/lightninglabs/lightning-terminal/releases/tag/v0.17.0-alpha

v0.17 bundles lnd `0.21.1-beta`, tapd `0.8.0`, loop `0.33.3-beta`, pool `0.7.1-beta`, faraday `0.2.16-alpha`, and adds native SQL (SQLite/Postgres) database backends. Notable fixes: LNC session setup for mailbox links restored; `litcli accounts update` expiration default fixed.

## Breaking change handled: bbolt → SQL migration

v0.17 migrates its internal `bbolt` databases to SQL **by default on the first restart after upgrade**, gated behind an explicit `yes` confirmation read from **stdin** (any other input, or no input, *cancels* `litd` startup). Our daemon runs `litd` with no interactive stdin, so an unhandled upgrade would break existing installs.

To keep startup non-interactive **and reversible**, this PR pins `databasebackend=bbolt` in `lit.conf` (the documented way to defer the migration). Behavior is unchanged for users; `bbolt` is deprecated upstream but still fully supported.

## Proposal (not implemented — for review)

Upstream recommends migrating to SQL for all users. That migration is **irreversible** (tombstones the bbolt db; blocks downgrade below v0.17). Rather than force it silently in an automated bump, I've deferred it. A reasonable follow-up is an **opt-in action** (or a config toggle) that sets `auto-migrate-to-sql=true` / drops the `databasebackend=bbolt` pin so users can migrate deliberately, with a warning that it can't be undone. Happy to implement if we want it.

## Other changes

- Added the missing `"name": "lightning-terminal-startos"` field to `package.json` (package-conformity; it was absent, which caused npm to write the slot dir name into the lockfile).
- `npm install` reconciled the root `@start9labs/start-sdk` to the pinned `1.5.3`. SDK is already at the latest published version (no bump needed).

### Note on `npm update`

`npm update` currently cannot complete: the transitive dependency `bitcoin-core-startos#next/28.x` (via `lnd-startos#next`) pins `@start9labs/start-sdk@2.0.0`, which is not yet published to npm. This is a pre-existing upstream-sibling state, unrelated to this bump. `npm install` succeeds and typecheck is green against the resolvable tree.

## Verification

- `npm run check` (tsc) — **green**.

Per the monitor cycle, `make` / s9pk pack / smoke-test are deferred to PR review.
