### PR TITLE
chore: bump Lightning Terminal to 0.17.0-alpha; 0.16.1-alpha:4 → 0.17.0-alpha:0

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,14 +75,15 @@ Settings managed by StartOS (hardcoded):
 | Setting | Value | Reason |
 |---------|-------|--------|
 | `uipassword` | Auto-generated | Set via Create/Reset Password action |
-| `databasebackend` | `bbolt` | Defer litd's own irreversible `bbolt`→SQL migration introduced upstream in v0.17.0 |
+| `databasebackend` | `sqlite` | Upstream default in v0.17.0; litd's own stores use SQLite |
+| `auto-migrate-to-sql` | `true` | Approve litd's one-way `bbolt`→SQL migration unattended (no `stdin` prompt available) |
 | `lit-dir` | `/root` | Maps to the mounted volume |
 | `insecure-httplisten` | `lightning-terminal.startos:8443` | StartOS service networking |
 | `remote.lnd.rpcserver` | `lnd.startos:10009` | StartOS service networking |
 | `remote.lnd.macaroonpath` | `/mnt/lnd/data/chain/bitcoin/mainnet/admin.macaroon` | Mounted dependency volume |
 | `remote.lnd.tlscertpath` | `/mnt/lnd/tls.cert` | Mounted dependency volume |
 
-Upstream v0.17.0 makes SQLite the default backend for litd's **own** internal databases — accounts, sessions, and firewall/autopilot rules — which litd maintains even in remote-LND mode. This is separate from the LND node's own database (the LND package manages that, including LND's own kvdb→SQL migration). On the first restart after upgrading, litd would migrate its internal stores one-way to SQL, prompting for confirmation on `stdin` that a headless StartOS daemon cannot answer (any input other than `yes` cancels litd startup). This package pins `databasebackend=bbolt` so existing installs keep their data and start unattended; `bbolt` remains supported upstream, now deprecated.
+Upstream v0.17.0 makes SQLite the default backend for litd's **own** internal databases — accounts, sessions, and firewall/autopilot rules — which litd maintains even in remote-LND mode. This is separate from the LND node's own database (the LND package manages that, including LND's own kvdb→SQL migration). On the first start after upgrading, litd migrates its internal stores one-way from `bbolt` to SQLite. That migration normally prompts for confirmation on `stdin`, which a headless StartOS daemon cannot answer, so this package sets `auto-migrate-to-sql=true` to approve it unattended. The migration is irreversible: once it runs you cannot downgrade below v0.17.0-alpha. It reads macaroon IDs from LND, so it needs the LND node running (StartOS shows a dependency warning if it isn't). The migration is transactional — if LND is unreachable the attempt aborts cleanly, leaves the `bbolt` data intact, and litd retries automatically on its next start.
 
 ---
 
@@ -151,7 +152,7 @@ LND must be installed and running. LiT connects via the mounted macaroon and TLS
 1. **Remote mode only** — LiT runs in remote mode connecting to a separate LND instance; integrated mode (where LiT runs its own LND) is not available
 2. **No user-configurable settings** — all configuration is managed by StartOS; the only user action is password management
 3. **Password-only authentication** — the UI password is auto-generated via the StartOS action; there is no option to set a custom password manually
-4. **Legacy `bbolt` database backend** — the package pins `databasebackend=bbolt` and does not run the upstream `bbolt`→SQL migration of litd's own internal stores (which is irreversible and cannot be confirmed from a headless daemon)
+4. **One-way SQLite migration** — on upgrade to v0.17.0, litd migrates its own internal stores from `bbolt` to SQLite (`auto-migrate-to-sql=true`); this is irreversible, so afterwards the package cannot be downgraded below v0.17.0-alpha
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -75,11 +75,14 @@ Settings managed by StartOS (hardcoded):
 | Setting | Value | Reason |
 |---------|-------|--------|
 | `uipassword` | Auto-generated | Set via Create/Reset Password action |
+| `databasebackend` | `bbolt` | Defer the irreversible `bbolt`→SQL migration introduced upstream in v0.17.0 |
 | `lit-dir` | `/root` | Maps to the mounted volume |
 | `insecure-httplisten` | `lightning-terminal.startos:8443` | StartOS service networking |
 | `remote.lnd.rpcserver` | `lnd.startos:10009` | StartOS service networking |
 | `remote.lnd.macaroonpath` | `/mnt/lnd/data/chain/bitcoin/mainnet/admin.macaroon` | Mounted dependency volume |
 | `remote.lnd.tlscertpath` | `/mnt/lnd/tls.cert` | Mounted dependency volume |
+
+Upstream v0.17.0 makes SQLite the default database backend and, on an existing `bbolt` database, prompts for a one-way migration to SQL that cannot be answered from a headless StartOS daemon (litd startup is canceled without confirmation). This package pins `databasebackend=bbolt` so existing installs keep their data and start unattended; `bbolt` remains supported upstream, now deprecated.
 
 ---
 
@@ -148,6 +151,7 @@ LND must be installed and running. LiT connects via the mounted macaroon and TLS
 1. **Remote mode only** — LiT runs in remote mode connecting to a separate LND instance; integrated mode (where LiT runs its own LND) is not available
 2. **No user-configurable settings** — all configuration is managed by StartOS; the only user action is password management
 3. **Password-only authentication** — the UI password is auto-generated via the StartOS action; there is no option to set a custom password manually
+4. **Legacy `bbolt` database backend** — the package pins `databasebackend=bbolt` and does not run the upstream `bbolt`→SQL migration (which is irreversible and cannot be confirmed from a headless daemon)
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -75,14 +75,14 @@ Settings managed by StartOS (hardcoded):
 | Setting | Value | Reason |
 |---------|-------|--------|
 | `uipassword` | Auto-generated | Set via Create/Reset Password action |
-| `databasebackend` | `bbolt` | Defer the irreversible `bbolt`→SQL migration introduced upstream in v0.17.0 |
+| `databasebackend` | `bbolt` | Defer litd's own irreversible `bbolt`→SQL migration introduced upstream in v0.17.0 |
 | `lit-dir` | `/root` | Maps to the mounted volume |
 | `insecure-httplisten` | `lightning-terminal.startos:8443` | StartOS service networking |
 | `remote.lnd.rpcserver` | `lnd.startos:10009` | StartOS service networking |
 | `remote.lnd.macaroonpath` | `/mnt/lnd/data/chain/bitcoin/mainnet/admin.macaroon` | Mounted dependency volume |
 | `remote.lnd.tlscertpath` | `/mnt/lnd/tls.cert` | Mounted dependency volume |
 
-Upstream v0.17.0 makes SQLite the default database backend and, on an existing `bbolt` database, prompts for a one-way migration to SQL that cannot be answered from a headless StartOS daemon (litd startup is canceled without confirmation). This package pins `databasebackend=bbolt` so existing installs keep their data and start unattended; `bbolt` remains supported upstream, now deprecated.
+Upstream v0.17.0 makes SQLite the default backend for litd's **own** internal databases — accounts, sessions, and firewall/autopilot rules — which litd maintains even in remote-LND mode. This is separate from the LND node's own database (the LND package manages that, including LND's own kvdb→SQL migration). On the first restart after upgrading, litd would migrate its internal stores one-way to SQL, prompting for confirmation on `stdin` that a headless StartOS daemon cannot answer (any input other than `yes` cancels litd startup). This package pins `databasebackend=bbolt` so existing installs keep their data and start unattended; `bbolt` remains supported upstream, now deprecated.
 
 ---
 
@@ -151,7 +151,7 @@ LND must be installed and running. LiT connects via the mounted macaroon and TLS
 1. **Remote mode only** — LiT runs in remote mode connecting to a separate LND instance; integrated mode (where LiT runs its own LND) is not available
 2. **No user-configurable settings** — all configuration is managed by StartOS; the only user action is password management
 3. **Password-only authentication** — the UI password is auto-generated via the StartOS action; there is no option to set a custom password manually
-4. **Legacy `bbolt` database backend** — the package pins `databasebackend=bbolt` and does not run the upstream `bbolt`→SQL migration (which is irreversible and cannot be confirmed from a headless daemon)
+4. **Legacy `bbolt` database backend** — the package pins `databasebackend=bbolt` and does not run the upstream `bbolt`→SQL migration of litd's own internal stores (which is irreversible and cannot be confirmed from a headless daemon)
 
 ---
 

--- a/startos/fileModels/lit.conf.ts
+++ b/startos/fileModels/lit.conf.ts
@@ -10,6 +10,8 @@ const tlsCertPath = `${lndMount}/tls.cert` as const
 
 const shape = z.object({
   uipassword: z.string().nullable().catch(null),
+  // Pin bbolt to defer litd 0.17's irreversible bbolt→SQL migration (SQLite is now the upstream default).
+  databasebackend: z.literal('bbolt').catch('bbolt'),
   'lit-dir': z.literal(litDir).catch(litDir),
   'insecure-httplisten': z.literal(httpListen).catch(httpListen),
   'remote.lnd.rpcserver': z.literal(rpcServer).catch(rpcServer),

--- a/startos/fileModels/lit.conf.ts
+++ b/startos/fileModels/lit.conf.ts
@@ -10,8 +10,9 @@ const tlsCertPath = `${lndMount}/tls.cert` as const
 
 const shape = z.object({
   uipassword: z.string().nullable().catch(null),
-  // Pin bbolt to defer litd 0.17's irreversible bbolt→SQL migration (SQLite is now the upstream default).
-  databasebackend: z.literal('bbolt').catch('bbolt'),
+  databasebackend: z.literal('sqlite').catch('sqlite'),
+  // Approve litd 0.17's one-way bbolt→SQL migration headlessly; no stdin prompt is answerable here.
+  'auto-migrate-to-sql': z.literal('true').catch('true'),
   'lit-dir': z.literal(litDir).catch(litDir),
   'insecure-httplisten': z.literal(httpListen).catch(httpListen),
   'remote.lnd.rpcserver': z.literal(rpcServer).catch(rpcServer),

--- a/startos/manifest/index.ts
+++ b/startos/manifest/index.ts
@@ -5,8 +5,7 @@ export const manifest = setupManifest({
   id: 'lightning-terminal',
   title: 'Lightning Terminal',
   license: 'mit',
-  packageRepo:
-    'https://github.com/Start9Labs/lightning-terminal-startos',
+  packageRepo: 'https://github.com/Start9Labs/lightning-terminal-startos',
   upstreamRepo: 'https://github.com/lightninglabs/lightning-terminal',
   marketingUrl: 'https://lightning.engineering/',
   donationUrl: null,
@@ -15,7 +14,7 @@ export const manifest = setupManifest({
   images: {
     'lightning-terminal': {
       source: {
-        dockerTag: 'lightninglabs/lightning-terminal:v0.16.1-alpha',
+        dockerTag: 'lightninglabs/lightning-terminal:v0.17.0-alpha',
       },
       arch: ['aarch64', 'x86_64'],
     },

--- a/startos/versions/current.ts
+++ b/startos/versions/current.ts
@@ -8,35 +8,35 @@ export const current = VersionInfo.of({
     en_US: `Updated Lightning Terminal to 0.17.0-alpha.
 
 - Bundles LND 0.21.1-beta, Taproot Assets 0.8.0, Loop 0.33.3-beta, Pool 0.7.1-beta, and Faraday 0.2.16-alpha.
-- Upstream adds native SQL (SQLite/Postgres) database support and deprecates bbolt. To protect existing data, this package keeps the legacy bbolt backend and defers the irreversible bbolt-to-SQL migration.
+- Migrates Lightning Terminal's own databases (accounts, sessions, firewall rules) from the legacy bbolt backend to SQLite, the new upstream default. This one-way migration runs automatically on first start; afterwards you cannot downgrade below 0.17.0-alpha, so back up before updating. This does not affect your LND node's database, which the LND package manages separately.
 - New upstream features: account renaming, custom session permissions, and asset-aware payment confirmations.
 
 Full release notes: https://github.com/lightninglabs/lightning-terminal/releases/tag/v0.17.0-alpha`,
     es_ES: `Se actualizó Lightning Terminal a 0.17.0-alpha.
 
 - Incluye LND 0.21.1-beta, Taproot Assets 0.8.0, Loop 0.33.3-beta, Pool 0.7.1-beta y Faraday 0.2.16-alpha.
-- El proyecto original añade soporte nativo de base de datos SQL (SQLite/Postgres) y marca bbolt como obsoleto. Para proteger los datos existentes, este paquete mantiene el backend heredado bbolt y aplaza la migración irreversible de bbolt a SQL.
+- Migra las bases de datos propias de Lightning Terminal (cuentas, sesiones, reglas del cortafuegos) del backend heredado bbolt a SQLite, el nuevo valor predeterminado del proyecto original. Esta migración unidireccional se ejecuta automáticamente en el primer inicio; después no podrás volver a una versión anterior a 0.17.0-alpha, así que haz una copia de seguridad antes de actualizar. Esto no afecta a la base de datos de tu nodo LND, que gestiona por separado el paquete de LND.
 - Nuevas funciones del proyecto original: cambio de nombre de cuentas, permisos personalizados de sesión y confirmaciones de pago que reconocen activos.
 
 Notas de la versión completas: https://github.com/lightninglabs/lightning-terminal/releases/tag/v0.17.0-alpha`,
     de_DE: `Lightning Terminal auf 0.17.0-alpha aktualisiert.
 
 - Enthält LND 0.21.1-beta, Taproot Assets 0.8.0, Loop 0.33.3-beta, Pool 0.7.1-beta und Faraday 0.2.16-alpha.
-- Upstream ergänzt native SQL-Datenbankunterstützung (SQLite/Postgres) und stuft bbolt als veraltet ein. Zum Schutz vorhandener Daten behält dieses Paket das bisherige bbolt-Backend bei und verschiebt die unumkehrbare Migration von bbolt zu SQL.
+- Migriert die eigenen Datenbanken von Lightning Terminal (Konten, Sitzungen, Firewall-Regeln) vom bisherigen bbolt-Backend zu SQLite, dem neuen Upstream-Standard. Diese unumkehrbare Migration läuft beim ersten Start automatisch; danach ist keine Rückstufung unter 0.17.0-alpha mehr möglich, erstelle daher vor dem Aktualisieren ein Backup. Die Datenbank deines LND-Knotens ist davon nicht betroffen; diese verwaltet das LND-Paket separat.
 - Neue Upstream-Funktionen: Umbenennen von Konten, benutzerdefinierte Sitzungsberechtigungen und asset-bewusste Zahlungsbestätigungen.
 
 Vollständige Versionshinweise: https://github.com/lightninglabs/lightning-terminal/releases/tag/v0.17.0-alpha`,
     pl_PL: `Zaktualizowano Lightning Terminal do 0.17.0-alpha.
 
 - Zawiera LND 0.21.1-beta, Taproot Assets 0.8.0, Loop 0.33.3-beta, Pool 0.7.1-beta i Faraday 0.2.16-alpha.
-- Projekt źródłowy dodaje natywną obsługę bazy danych SQL (SQLite/Postgres) i oznacza bbolt jako przestarzały. Aby chronić istniejące dane, ten pakiet pozostaje przy starszym backendzie bbolt i odracza nieodwracalną migrację z bbolt do SQL.
+- Migruje własne bazy danych Lightning Terminal (konta, sesje, reguły zapory) ze starszego backendu bbolt do SQLite, nowego domyślnego backendu projektu źródłowego. Ta jednokierunkowa migracja uruchamia się automatycznie przy pierwszym starcie; po niej nie można wrócić do wersji starszej niż 0.17.0-alpha, więc przed aktualizacją wykonaj kopię zapasową. Nie ma to wpływu na bazę danych węzła LND, którą osobno zarządza pakiet LND.
 - Nowe funkcje projektu źródłowego: zmiana nazwy kont, niestandardowe uprawnienia sesji oraz potwierdzenia płatności uwzględniające aktywa.
 
 Pełne informacje o wydaniu: https://github.com/lightninglabs/lightning-terminal/releases/tag/v0.17.0-alpha`,
     fr_FR: `Lightning Terminal mis à jour vers 0.17.0-alpha.
 
 - Intègre LND 0.21.1-beta, Taproot Assets 0.8.0, Loop 0.33.3-beta, Pool 0.7.1-beta et Faraday 0.2.16-alpha.
-- En amont, ajout de la prise en charge native des bases de données SQL (SQLite/Postgres) et dépréciation de bbolt. Pour protéger les données existantes, ce paquet conserve l'ancien backend bbolt et reporte la migration irréversible de bbolt vers SQL.
+- Migre les bases de données propres à Lightning Terminal (comptes, sessions, règles de pare-feu) de l'ancien backend bbolt vers SQLite, la nouvelle valeur par défaut en amont. Cette migration à sens unique s'exécute automatiquement au premier démarrage ; ensuite, vous ne pourrez plus revenir à une version antérieure à 0.17.0-alpha, alors faites une sauvegarde avant de mettre à jour. Cela n'affecte pas la base de données de votre nœud LND, gérée séparément par le paquet LND.
 - Nouvelles fonctionnalités en amont : renommage des comptes, permissions de session personnalisées et confirmations de paiement tenant compte des actifs.
 
 Notes de version complètes : https://github.com/lightninglabs/lightning-terminal/releases/tag/v0.17.0-alpha`,

--- a/startos/versions/current.ts
+++ b/startos/versions/current.ts
@@ -3,13 +3,43 @@ import { readFile, rm } from 'fs/promises'
 import { litConfig } from '../fileModels/lit.conf'
 
 export const current = VersionInfo.of({
-  version: '0.16.1-alpha:4',
+  version: '0.17.0-alpha:0',
   releaseNotes: {
-    en_US: 'Internal updates (start-sdk 1.5.0)',
-    es_ES: 'Actualizaciones internas (start-sdk 1.5.0)',
-    de_DE: 'Interne Aktualisierungen (start-sdk 1.5.0)',
-    pl_PL: 'Aktualizacje wewnętrzne (start-sdk 1.5.0)',
-    fr_FR: 'Mises à jour internes (start-sdk 1.5.0)',
+    en_US: `Updated Lightning Terminal to 0.17.0-alpha.
+
+- Bundles LND 0.21.1-beta, Taproot Assets 0.8.0, Loop 0.33.3-beta, Pool 0.7.1-beta, and Faraday 0.2.16-alpha.
+- Upstream adds native SQL (SQLite/Postgres) database support and deprecates bbolt. To protect existing data, this package keeps the legacy bbolt backend and defers the irreversible bbolt-to-SQL migration.
+- New upstream features: account renaming, custom session permissions, and asset-aware payment confirmations.
+
+Full release notes: https://github.com/lightninglabs/lightning-terminal/releases/tag/v0.17.0-alpha`,
+    es_ES: `Se actualizó Lightning Terminal a 0.17.0-alpha.
+
+- Incluye LND 0.21.1-beta, Taproot Assets 0.8.0, Loop 0.33.3-beta, Pool 0.7.1-beta y Faraday 0.2.16-alpha.
+- El proyecto original añade soporte nativo de base de datos SQL (SQLite/Postgres) y marca bbolt como obsoleto. Para proteger los datos existentes, este paquete mantiene el backend heredado bbolt y aplaza la migración irreversible de bbolt a SQL.
+- Nuevas funciones del proyecto original: cambio de nombre de cuentas, permisos personalizados de sesión y confirmaciones de pago que reconocen activos.
+
+Notas de la versión completas: https://github.com/lightninglabs/lightning-terminal/releases/tag/v0.17.0-alpha`,
+    de_DE: `Lightning Terminal auf 0.17.0-alpha aktualisiert.
+
+- Enthält LND 0.21.1-beta, Taproot Assets 0.8.0, Loop 0.33.3-beta, Pool 0.7.1-beta und Faraday 0.2.16-alpha.
+- Upstream ergänzt native SQL-Datenbankunterstützung (SQLite/Postgres) und stuft bbolt als veraltet ein. Zum Schutz vorhandener Daten behält dieses Paket das bisherige bbolt-Backend bei und verschiebt die unumkehrbare Migration von bbolt zu SQL.
+- Neue Upstream-Funktionen: Umbenennen von Konten, benutzerdefinierte Sitzungsberechtigungen und asset-bewusste Zahlungsbestätigungen.
+
+Vollständige Versionshinweise: https://github.com/lightninglabs/lightning-terminal/releases/tag/v0.17.0-alpha`,
+    pl_PL: `Zaktualizowano Lightning Terminal do 0.17.0-alpha.
+
+- Zawiera LND 0.21.1-beta, Taproot Assets 0.8.0, Loop 0.33.3-beta, Pool 0.7.1-beta i Faraday 0.2.16-alpha.
+- Projekt źródłowy dodaje natywną obsługę bazy danych SQL (SQLite/Postgres) i oznacza bbolt jako przestarzały. Aby chronić istniejące dane, ten pakiet pozostaje przy starszym backendzie bbolt i odracza nieodwracalną migrację z bbolt do SQL.
+- Nowe funkcje projektu źródłowego: zmiana nazwy kont, niestandardowe uprawnienia sesji oraz potwierdzenia płatności uwzględniające aktywa.
+
+Pełne informacje o wydaniu: https://github.com/lightninglabs/lightning-terminal/releases/tag/v0.17.0-alpha`,
+    fr_FR: `Lightning Terminal mis à jour vers 0.17.0-alpha.
+
+- Intègre LND 0.21.1-beta, Taproot Assets 0.8.0, Loop 0.33.3-beta, Pool 0.7.1-beta et Faraday 0.2.16-alpha.
+- En amont, ajout de la prise en charge native des bases de données SQL (SQLite/Postgres) et dépréciation de bbolt. Pour protéger les données existantes, ce paquet conserve l'ancien backend bbolt et reporte la migration irréversible de bbolt vers SQL.
+- Nouvelles fonctionnalités en amont : renommage des comptes, permissions de session personnalisées et confirmations de paiement tenant compte des actifs.
+
+Notes de version complètes : https://github.com/lightninglabs/lightning-terminal/releases/tag/v0.17.0-alpha`,
   },
   migrations: {
     up: async ({ effects }) => {


### PR DESCRIPTION
## Summary

Bumps Lightning Terminal from **v0.16.1-alpha** to **v0.17.0-alpha** (upstream released 2026-06-30). StartOS version `0.16.1-alpha:4` → `0.17.0-alpha:0`.

The v0.17.0-alpha image bundles **LND 0.21.1-beta**, **Taproot Assets 0.8.0**, **Loop 0.33.3-beta**, **Pool 0.7.1-beta**, and **Faraday 0.2.16-alpha**.

Full upstream notes: https://github.com/lightninglabs/lightning-terminal/releases/tag/v0.17.0-alpha

## Database backend — bbolt → SQLite migration

v0.17.0 introduces a native SQL (SQLite/Postgres) backend for litd's **own** internal stores (accounts, sessions, firewall/autopilot rules) and makes **SQLite the default**. This is separate from the external LND node's database, which the `lnd-startos` package manages (LND has its own, unrelated kvdb→SQL migration). On an existing install with bbolt data, litd normally prompts on `stdin` for a one-way migration — which a headless StartOS daemon can't answer.

Per maintainer decision (see thread), this package **performs** the migration rather than deferring it. The `lit.conf` model sets:

- `databasebackend=sqlite` (the new upstream default)
- `auto-migrate-to-sql=true` (litd's documented way to approve the migration headlessly)

Both are seeded on every init (`litConfig.merge`) before the daemon starts. Behavior verified against litd `v0.17.0-alpha` source:

- **Transactional / crash-safe** — the migration runs in a transaction with `ResetVersionOnError`; bbolt is tombstoned only *after* the SQL commit succeeds. A failed attempt rolls back cleanly, leaves bbolt intact, and retries on next start.
- **Idempotent** — no-op on fresh installs (no bbolt files) and on every boot after the tombstone.
- **First-boot ordering** — the migration reads macaroon IDs from LND (retried ~60s); if LND isn't reachable yet, litd aborts cleanly and its daemon restarts until LND is up.
- **Irreversible** — after migrating, the package cannot be downgraded below `0.17.0-alpha`. Release notes recommend a pre-update backup; the version file keeps `down: IMPOSSIBLE`.

The pre-existing `config.yaml`→`uipassword` migration is preserved; the version file is edited in place.

## Notable upstream features in 0.17.0

- Account renaming (`litcli accounts update --new_label`)
- Custom per-session permissions (`--permission`)
- Asset-aware payment confirmations

## Dependencies

- `@start9labs/start-sdk` at npm-latest **1.5.3** — no SDK bump.
- LND dependency `versionRange` left at `>=0.20.1-beta:2` (remote-mode minimum for litd 0.17 is v0.19.0-beta, already satisfied).

## Test plan

- [x] `npm run check` (tsc --noEmit) passes; prettier clean.
- [x] `make` builds both x86_64 and aarch64 s9pks.
- [x] Migration mechanics + safety verified against litd v0.17.0-alpha source and adversarially reviewed.

New StartOS version after this PR: **`0.17.0-alpha:0`**.
