### PR TITLE
fix: restart litd when the UI password changes so a reset takes effect

### DIFF
--- a/startos/actions/resetPassword.ts
+++ b/startos/actions/resetPassword.ts
@@ -9,8 +9,7 @@ export const resetPassword = sdk.Action.withoutInput(
 
   // metadata
   async ({ effects }) => {
-    const hasPass =
-      (await litConfig.read((c) => c.uipassword).const(effects)) !== 'null'
+    const hasPass = !!(await litConfig.read((c) => c.uipassword).const(effects))
 
     return {
       name: hasPass ? i18n('Reset Password') : i18n('Create Password'),

--- a/startos/main.ts
+++ b/startos/main.ts
@@ -1,10 +1,13 @@
 import { manifest as lndManifest } from 'lnd-startos/startos/manifest'
+import { litConfig } from './fileModels/lit.conf'
 import { i18n } from './i18n'
 import { sdk } from './sdk'
 import { litDir, lndMount, uiPort } from './utils'
 
 export const main = sdk.setupMain(async ({ effects }) => {
   console.info(i18n('Starting Lightning Terminal...'))
+  // Restart litd whenever lit.conf changes so config edits take effect (litd reads it only at startup).
+  await litConfig.read().const(effects)
   return sdk.Daemons.of(effects).addDaemon('lit', {
     subcontainer: await sdk.SubContainer.of(
       effects,

--- a/startos/versions/current.ts
+++ b/startos/versions/current.ts
@@ -3,43 +3,18 @@ import { readFile, rm } from 'fs/promises'
 import { litConfig } from '../fileModels/lit.conf'
 
 export const current = VersionInfo.of({
-  version: '0.17.0-alpha:0',
+  version: '0.17.0-alpha:1',
   releaseNotes: {
-    en_US: `Updated Lightning Terminal to 0.17.0-alpha.
-
-- Bundles LND 0.21.1-beta, Taproot Assets 0.8.0, Loop 0.33.3-beta, Pool 0.7.1-beta, and Faraday 0.2.16-alpha.
-- Migrates Lightning Terminal's own databases (accounts, sessions, firewall rules) from the legacy bbolt backend to SQLite, the new upstream default. This one-way migration runs automatically on first start; afterwards you cannot downgrade below 0.17.0-alpha, so back up before updating. This does not affect your LND node's database, which the LND package manages separately.
-- New upstream features: account renaming, custom session permissions, and asset-aware payment confirmations.
-
-Full release notes: https://github.com/lightninglabs/lightning-terminal/releases/tag/v0.17.0-alpha`,
-    es_ES: `Se actualizó Lightning Terminal a 0.17.0-alpha.
-
-- Incluye LND 0.21.1-beta, Taproot Assets 0.8.0, Loop 0.33.3-beta, Pool 0.7.1-beta y Faraday 0.2.16-alpha.
-- Migra las bases de datos propias de Lightning Terminal (cuentas, sesiones, reglas del cortafuegos) del backend heredado bbolt a SQLite, el nuevo valor predeterminado del proyecto original. Esta migración unidireccional se ejecuta automáticamente en el primer inicio; después no podrás volver a una versión anterior a 0.17.0-alpha, así que haz una copia de seguridad antes de actualizar. Esto no afecta a la base de datos de tu nodo LND, que gestiona por separado el paquete de LND.
-- Nuevas funciones del proyecto original: cambio de nombre de cuentas, permisos personalizados de sesión y confirmaciones de pago que reconocen activos.
-
-Notas de la versión completas: https://github.com/lightninglabs/lightning-terminal/releases/tag/v0.17.0-alpha`,
-    de_DE: `Lightning Terminal auf 0.17.0-alpha aktualisiert.
-
-- Enthält LND 0.21.1-beta, Taproot Assets 0.8.0, Loop 0.33.3-beta, Pool 0.7.1-beta und Faraday 0.2.16-alpha.
-- Migriert die eigenen Datenbanken von Lightning Terminal (Konten, Sitzungen, Firewall-Regeln) vom bisherigen bbolt-Backend zu SQLite, dem neuen Upstream-Standard. Diese unumkehrbare Migration läuft beim ersten Start automatisch; danach ist keine Rückstufung unter 0.17.0-alpha mehr möglich, erstelle daher vor dem Aktualisieren ein Backup. Die Datenbank deines LND-Knotens ist davon nicht betroffen; diese verwaltet das LND-Paket separat.
-- Neue Upstream-Funktionen: Umbenennen von Konten, benutzerdefinierte Sitzungsberechtigungen und asset-bewusste Zahlungsbestätigungen.
-
-Vollständige Versionshinweise: https://github.com/lightninglabs/lightning-terminal/releases/tag/v0.17.0-alpha`,
-    pl_PL: `Zaktualizowano Lightning Terminal do 0.17.0-alpha.
-
-- Zawiera LND 0.21.1-beta, Taproot Assets 0.8.0, Loop 0.33.3-beta, Pool 0.7.1-beta i Faraday 0.2.16-alpha.
-- Migruje własne bazy danych Lightning Terminal (konta, sesje, reguły zapory) ze starszego backendu bbolt do SQLite, nowego domyślnego backendu projektu źródłowego. Ta jednokierunkowa migracja uruchamia się automatycznie przy pierwszym starcie; po niej nie można wrócić do wersji starszej niż 0.17.0-alpha, więc przed aktualizacją wykonaj kopię zapasową. Nie ma to wpływu na bazę danych węzła LND, którą osobno zarządza pakiet LND.
-- Nowe funkcje projektu źródłowego: zmiana nazwy kont, niestandardowe uprawnienia sesji oraz potwierdzenia płatności uwzględniające aktywa.
-
-Pełne informacje o wydaniu: https://github.com/lightninglabs/lightning-terminal/releases/tag/v0.17.0-alpha`,
-    fr_FR: `Lightning Terminal mis à jour vers 0.17.0-alpha.
-
-- Intègre LND 0.21.1-beta, Taproot Assets 0.8.0, Loop 0.33.3-beta, Pool 0.7.1-beta et Faraday 0.2.16-alpha.
-- Migre les bases de données propres à Lightning Terminal (comptes, sessions, règles de pare-feu) de l'ancien backend bbolt vers SQLite, la nouvelle valeur par défaut en amont. Cette migration à sens unique s'exécute automatiquement au premier démarrage ; ensuite, vous ne pourrez plus revenir à une version antérieure à 0.17.0-alpha, alors faites une sauvegarde avant de mettre à jour. Cela n'affecte pas la base de données de votre nœud LND, gérée séparément par le paquet LND.
-- Nouvelles fonctionnalités en amont : renommage des comptes, permissions de session personnalisées et confirmations de paiement tenant compte des actifs.
-
-Notes de version complètes : https://github.com/lightninglabs/lightning-terminal/releases/tag/v0.17.0-alpha`,
+    en_US: `- Fixes the Create/Reset Password action so a newly generated password takes effect immediately instead of being ignored until the next restart.
+- Restores the correct "Create Password" label before a password has been set.`,
+    es_ES: `- Corrige la acción Crear/Restablecer contraseña para que una contraseña recién generada surta efecto de inmediato en lugar de ignorarse hasta el siguiente reinicio.
+- Restaura la etiqueta correcta «Crear contraseña» antes de que se haya establecido una contraseña.`,
+    de_DE: `- Behebt die Aktion „Passwort erstellen/zurücksetzen“, sodass ein neu generiertes Passwort sofort wirksam wird, statt bis zum nächsten Neustart ignoriert zu werden.
+- Stellt die korrekte Bezeichnung „Passwort erstellen“ wieder her, solange noch kein Passwort gesetzt ist.`,
+    pl_PL: `- Naprawia akcję Utwórz/Zresetuj hasło, dzięki czemu nowo wygenerowane hasło działa natychmiast, zamiast być ignorowane do następnego restartu.
+- Przywraca poprawną etykietę „Utwórz hasło”, zanim hasło zostanie ustawione.`,
+    fr_FR: `- Corrige l'action Créer/Réinitialiser le mot de passe pour qu'un mot de passe nouvellement généré prenne effet immédiatement au lieu d'être ignoré jusqu'au prochain redémarrage.
+- Rétablit le libellé correct « Créer le mot de passe » tant qu'aucun mot de passe n'a été défini.`,
   },
   migrations: {
     up: async ({ effects }) => {


### PR DESCRIPTION
## Problem

A user reported that the latest release (**0.17.0-alpha:0**) broke the reset-password action — a newly generated password never lets you log in.

## Root cause

The `reset-password` action writes the new `uipassword` to `.lit/lit.conf` (`litConfig.merge`), but **litd reads its config only once, at startup** — `uipassword` becomes the `base64(pw:pw)` HTTP basic-auth credential and is cached (`rpc_proxy.go`), with no live reload. So a new password only takes effect when litd restarts.

In start-sdk, a daemon restarts when a file-model value it read with `.const(effects)` in `setupMain` changes. The **"beta 55" refactor (6a4ad51)** removed `main.ts`'s reactive read of the config, so writing a new password no longer restarted litd — the action wrote the file and appeared to do nothing. This first reached users in `0.17.0-alpha:0`.

## Fix

Restore a reactive read in `setupMain`, watching the **whole** `lit.conf` so *any* managed config change restarts litd (not just the password — litd reads everything in that file only at startup):

```ts
// Restart litd whenever lit.conf changes so config edits take effect (litd reads it only at startup).
await litConfig.read().const(effects)
```

### Why this can't cause a restart loop

- **litd never rewrites `lit.conf`** — it only parses it at startup (`flags.NewIniParser(...).ParseFile(...)`); there is no `WriteFile`/`Create` on the config path anywhere in the litd source. So litd can't self-trigger a restart.
- **The SDK's `.const()` deduplicates by value** — `FileHelper`'s watch generator only yields (and only then reruns `setupMain`) when the newly-read, validated object is *not* `deepEqual` to the previous one. So `seedFiles`' identical merge on each init, or any identical rewrite, is ignored. Only a genuine content change restarts the daemon.

Fresh-install is unaffected: `taskSetPassword` raises a `critical` own-task that blocks startup until the password is set, so litd never starts without one.

Also fixes a secondary bug in the same action's metadata: it compared `uipassword` to the string `'null'` (always true), so the action was always labelled **Reset Password**. It now uses a truthy check, so it correctly shows **Create Password** before a password is set — as both the README and instructions describe.

## Verification

- Confirmed against the upstream litd v0.17.0-alpha source (no config writes) and the start-sdk `FileHelper`/`Watchable` source (value-based dedup) in both 1.5.3 and 2.0.1.
- `tsc --noEmit` and `make` (packs `lightning-terminal_x86_64.s9pk`, `v0.17.0-alpha:1`) pass.
- Docs reviewed: README and instructions already describe this behavior; no changes needed.

## Versioning / coordination

Bumps `0.17.0-alpha:0 → 0.17.0-alpha:1` in place (no migration). The start-sdk 2.0 PR (#59) had the same missing reactive read; it's been updated with the same whole-file watch and renumbered to `:2` so this standalone fix ships first as `:1` for current (beta.9) users.